### PR TITLE
fixed typos and tested with local DB_URL

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -7,7 +7,7 @@ const sequelize = process.env.DB_URL
   ? new Sequelize(process.env.DB_URL, {
       hooks: {
         beforeDefine: function (columns, model) {
-          model.tableName = `${process.end.DB_NAME}_${model.name.singluar}`;
+          model.tableName = `${process.env.DB_NAME}_${model.name.singular}`;
         },
       },
     })


### PR DESCRIPTION
tested locally by adding DB_URL to my .env file

DB_URL=postgresql://postgres:postgres@localhost:5432/greentrail_db

**which means the following**
postgresql = the DB type, same on all our machines
postgres:postgres = user:password, so on your machine you would substitute your DB username (if different) and pwd (if different)

@localhost:5432/greentrail_db = same on all our machines, it's the host, port and db name