### PR TITLE
updated eat-details handlebars page

### DIFF
--- a/views/partials/eat-details.handlebars
+++ b/views/partials/eat-details.handlebars
@@ -1,17 +1,13 @@
- <section>
-<h1>Restaurants</h1>
-    {{#if restaurants}}
-      <ul>
-        {{#each restaurants}}
-          <li>
-            <h2>{{site_name}}</h2>
-            <p><strong>{{provider_name}}</strong> </p>
-            {{!-- <p><strong>Description:</strong> {{description}}</p> --}}
-            <a href="{{map_link}}">View on Map</a>
-          </li>
-        {{/each}}
-      </ul>
-    {{else}}
-      <p>No restaurants found.</p>
-    {{/if}}
-</section> 
+<section>
+    <h2>Places to Eat in this Community!</h2>
+    {{#each community.providers as |provider|}}
+    {{#ifvalue provider.service value='restaurant'}}
+    Restaurant Name:
+    <h3>{{provider.provider_name}}</h3>
+    <h4>{{provider.site.description}}</h4>
+    Located At:
+    <h4>{{provider.site.street_address}}</h4>
+    <p>Enjoy your meal! <a href="{{provider.site.map_link}}">here!</a></p>
+    {{/ifvalue}}
+    {{/each}}
+</section>


### PR DESCRIPTION
❗ Please **DO NOT** open a Pull Request without creating an Issue first. Failure to do so will result in the rejection of the pull request.

## Purpose

updates the eat-details.handlebars page. Correctly pulls data and renders on the Community page. Not styled with CSS yet.

Fixes #173 

## Changes

Adjusts the handlebars page to effectively render all restaurant data on the Community page. 

## Steps to Reproduce or Test

After npm run start, navigate to the Chacala community page and click "Eat" to see restaurants populated below.

## Optional GIF

Self-explanatory.